### PR TITLE
Remove the use of "sudo xi"

### DIFF
--- a/src/package-update-tutorial.md
+++ b/src/package-update-tutorial.md
@@ -100,7 +100,7 @@ You can now build packages in
 
 You can install built packages with
 ```
-sudo xi -f <package>
+xi -f <package>
 ```
 
 (The `xi` utility is provided by the `xtools` package.)

--- a/src/packaging-j4-dmenu-desktop.md
+++ b/src/packaging-j4-dmenu-desktop.md
@@ -317,7 +317,7 @@ You can then build packages in
 
 You can install built packages with
 ```
-sudo xi -f <package>
+xi -f <package>
 ```
 (The `xi` utility is provided by the `xtools` package.)
 
@@ -824,7 +824,7 @@ to build a template.
 
 We use
 ```
-sudo xi -f j4-dmenu-desktop
+xi -f j4-dmenu-desktop
 ```
 to install a template.
 
@@ -1480,7 +1480,7 @@ to build a template.
 
 We use
 ```
-sudo xi -f j4-dmenu-desktop
+xi -f j4-dmenu-desktop
 ```
 to install a template.
 


### PR DESCRIPTION
The use of "sudo" is not required, as xtools' xi will call sudo/doas/su
by itself, and it would be best not to instruct new users to use sudo
needlessly.